### PR TITLE
fix: proper type checking on targets

### DIFF
--- a/grow/default.nix
+++ b/grow/default.nix
@@ -108,12 +108,15 @@
             if l.typeOf block == "set"
             then block
             else block signature;
-          imported =
-            if isFile
-            then Target' oPath.file' (import' oPath.file' oPath.file)
-            else if isDir
-            then Target' oPath.dir' (import' oPath.dir' oPath.dir)
-            else throw "unreachable!";
+          imported = let
+            block =
+              if isFile
+              then oPath.file' (import' oPath.file' oPath.file)
+              else if isDir
+              then oPath.dir' (import' oPath.dir' oPath.dir)
+              else throw "unreachable!";
+          in
+            Target' (cellBlock.__type or null) block;
           # extract instatiates actions and extracts metadata for the __std registry
           extracted = l.optionalAttrs (cellBlock.cli or true) (l.mapAttrs (_extract cellBlock) imported);
         in

--- a/grow/default.nix
+++ b/grow/default.nix
@@ -116,7 +116,7 @@
           Target' = {displayPath, ...}: Target "paisano/import: ${displayPath}";
           imported = import' importPaths;
           # type checked import
-          imported' = Target' importPaths ((cellBlock.type or null) imported);
+          imported' = Target' importPaths ((cellBlock.__type or null) imported);
           # extract instatiates actions and extracts metadata for the __std registry
           extracted = l.optionalAttrs (cellBlock.cli or true) (l.mapAttrs (_extract cellBlock) imported');
         in

--- a/types/default.nix
+++ b/types/default.nix
@@ -22,10 +22,10 @@
       list (struct "cellBlock" {
         name = string;
         type = string;
+        __type = option type;
         __functor = option function;
         ci = option (attrs bool);
         cli = option bool;
-        type = option type;
         actions = option (functionWithArgs {
           system = false;
           target = false;

--- a/types/default.nix
+++ b/types/default.nix
@@ -7,15 +7,15 @@
     inherit l;
     inherit (paths) cellPath cellBlockPath;
   };
-  Target = log:
-    with yants log;
-    # unfortunately eval during check can cause infinite recursions
-    # if blockType == "runnables" || blockType == "installables"
-    # then attrs drv
-    # else if blockType == "functions"
-    # then attrs function
-    # else throw "unreachable";
-      attrs any;
+  Target = log: type:
+    with yants log; let
+      type' =
+        # TODO: remove in the future and make a specific type a hard requirement
+        if type == null
+        then any
+        else type;
+    in
+      attrs type';
   Systems = log: with yants log; list (enum "system" l.systems.doubles.all);
   BlockTypes = log:
     with yants log;

--- a/types/default.nix
+++ b/types/default.nix
@@ -25,6 +25,7 @@
         __functor = option function;
         ci = option (attrs bool);
         cli = option bool;
+        type = option type;
         actions = option (functionWithArgs {
           system = false;
           target = false;


### PR DESCRIPTION
Blocktypes can define their own custom yants types and they will be checked properly, giving us some actual type safety.

Leaving in draft until I can implement some times in Standard upstream and test this properly. Also need to double check if this is breaks laziness.