### PR TITLE
feat: allow setting metadata in the CI registry

### DIFF
--- a/grow/newExtractFor.nix
+++ b/grow/newExtractFor.nix
@@ -55,6 +55,9 @@ This file implements an extractor that feeds the registry.
       }
       // (
         l.optionalAttrs (action' ? proviso) {inherit (action') proviso;}
+      )
+      // (
+        l.optionalAttrs (action' ? meta) {inherit (action') meta;}
       );
   in
     map f ci;

--- a/registry.schema.json
+++ b/registry.schema.json
@@ -168,6 +168,10 @@
                 "proviso": {
                   "type": "string",
                   "description": "A provisio which lets a CI cheaply decide whether running an action can be skipped."
+                },
+                "meta": {
+                  "type": "string",
+                  "description": "Arbitrary metadata needed during the priviso or discovery."
                 }
               },
               "required": ["actionDrv"]


### PR DESCRIPTION
Allows setting metadata in the blocktype to allow for useful
information to be passed into the proviso.

needed by divnix/std#267