### PR TITLE
Simplify ci register

### DIFF
--- a/grow/default.nix
+++ b/grow/default.nix
@@ -150,10 +150,6 @@
             {
               ci = l.mapAttrsToList (_: set: set.ci) extracted;
             }
-            # __std.ci'
-            {
-              ci' = l.mapAttrsToList (_: set: set.ci') extracted;
-            }
           ];
         res = accumulate (l.map loadCellBlock cellBlocks');
       in [
@@ -172,10 +168,6 @@
         # __std.ci
         {
           inherit (res) ci;
-        }
-        # __std.ci'
-        {
-          inherit (res) ci';
         }
       ]; # };
       res = accumulate (l.map loadCellFor cells');
@@ -198,15 +190,6 @@
           }
         ];
       }
-      # __std.ci'
-      {
-        ci' = [
-          {
-            name = system;
-            value = res.ci';
-          }
-        ];
-      }
     ];
     res = accumulate (l.map loadOutputFor systems');
   in
@@ -215,7 +198,6 @@
       // {
         __std.__schema = "v0";
         __std.ci = l.listToAttrs res.ci;
-        __std.ci' = l.listToAttrs res.ci';
         __std.init = l.listToAttrs res.init;
         __std.actions = res.actions;
         __std.cellsFrom = l.baseNameOf cellsFrom;

--- a/grow/newExtractFor.nix
+++ b/grow/newExtractFor.nix
@@ -37,22 +37,17 @@ This file implements an extractor that feeds the registry.
               ---
               ${l.generators.toPretty {} (l.removeAttrs cellBlock ["__functor"])}
             ''
-          else
-            {
-              inherit name;
-              cell = cellName;
-              block = cellBlock.name;
-              blockType = cellBlock.type;
-              inherit action;
-              targetDrv = command.targetDrv or target.drvPath or null; # can be null: nomad mainfests only hold data
-              actionDrv = command.drvPath;
-            }
-            // (
-              l.optionalAttrs (action' ? proviso) {inherit (action') proviso;}
-            )
-            // (
-              l.optionalAttrs (action' ? meta) {inherit (action') meta;}
-            )
+          else {
+            inherit name;
+            cell = cellName;
+            block = cellBlock.name;
+            blockType = cellBlock.type;
+            inherit action;
+            targetDrv = command.targetDrv or target.drvPath or null; # can be null: nomad mainfests only hold data
+            actionDrv = command.drvPath;
+            proviso = action'.proviso or null;
+            meta = action'.meta or null;
+          }
         )
       )
       cellBlock.ci
@@ -72,6 +67,6 @@ in {
         })
         actions';
     }
-    // (l.optionalAttrs (l.pathExists tPath.readme) {inherit (tPath) readme;})
-    // (l.optionalAttrs (target ? meta && target.meta ? description) {inherit (target.meta) description;});
+    // l.optionalAttrs (l.pathExists tPath.readme) {inherit (tPath) readme;}
+    // l.optionalAttrs (target ? meta && target.meta ? description) {inherit (target.meta) description;};
 }

--- a/grow/newHelpers.nix
+++ b/grow/newHelpers.nix
@@ -9,12 +9,10 @@ This file implements aggregation helper for collecting blocks.
         first = l.head new;
         second = l.head cdr;
         third = l.head cdr';
-        fourth = l.head cdr_;
-        tail = l.tail cdr_;
+        tail = l.tail cdr';
 
         cdr = l.tail new;
         cdr' = l.tail cdr;
-        cdr_ = l.tail cdr';
       in
         (
           if first == null
@@ -32,14 +30,9 @@ This file implements aggregation helper for collecting blocks.
           else {init = acc.init ++ [third];}
         )
         // (
-          if fourth == null
-          then {inherit (acc) ci;}
-          else {ci = acc.ci ++ (l.concatMap (t: l.flatten t.ci) [fourth]);}
-        )
-        // (
           if tail == [null]
-          then {inherit (acc) ci';}
-          else {ci' = acc.ci' ++ (l.concatMap (t: l.flatten t.ci') tail);}
+          then {inherit (acc) ci;}
+          else {ci = acc.ci ++ (l.concatMap (t: l.flatten t.ci) tail);}
         )
     )
     {
@@ -47,7 +40,6 @@ This file implements aggregation helper for collecting blocks.
       actions = {};
       init = [];
       ci = [];
-      ci' = []; # with drv (eval-costly)
     };
 
   optionalLoad = cond: elem:
@@ -58,6 +50,5 @@ This file implements aggregation helper for collecting blocks.
       null # empty action
       null # empty init
       null # empty ci
-      null # empty ci'
     ];
 }

--- a/registry.schema.json
+++ b/registry.schema.json
@@ -16,33 +16,23 @@
       "description": "Relative path to the repository root from which cells are discovered.",
       "type": "string"
     },
-    "ci": { "$ref": "#/definitions/ci" },
-    "ci'": { "$ref": "#/definitions/ci-prime" },
-    "init": { "$ref": "#/definitions/init" },
-    "actions": { "$ref": "#/definitions/actions" }
-  },
-  "required": ["__schema", "ci", "ci'", "init", "actions", "cellsFrom"],
-
-  "$defs": {
-    "ci-task": {
-      "title": "CI Task w/o Drvs",
-      "description": "A representation of a CI task's metadata.",
-      "type": "object",
-      "properties": {
-        "action": {
-          "type": "string",
-          "description": "The name of the action."
-        },
-        "block": { "type": "string", "description": "The block name." },
-        "blockType": { "type": "string", "description": "The block type." },
-        "cell": { "type": "string", "description": "The cell name." },
-        "name": { "type": "string", "description": "The target name." }
-      },
-      "required": ["action", "block", "blockType", "cell", "name"]
+    "ci": {
+      "$ref": "#/definitions/ci"
     },
-    "ci-task-prime": {}
+    "init": {
+      "$ref": "#/definitions/init"
+    },
+    "actions": {
+      "$ref": "#/definitions/actions"
+    }
   },
-
+  "required": [
+    "__schema",
+    "ci",
+    "init",
+    "actions",
+    "cellsFrom"
+  ],
   "definitions": {
     "actions": {
       "title": "Actions",
@@ -86,28 +76,46 @@
           "title": "Cell",
           "description": "The representational data of a cell.",
           "type": "object",
-          "required": ["cell", "cellBlocks"],
+          "required": [
+            "cell",
+            "cellBlocks"
+          ],
           "properties": {
-            "cell": { "type": "string" },
+            "cell": {
+              "type": "string"
+            },
             "cellBlocks": {
               "type": "array",
               "items": {
                 "title": "Block",
                 "description": "The representational data of a block.",
                 "type": "object",
-                "required": ["blockType", "cellBlock", "targets"],
+                "required": [
+                  "blockType",
+                  "cellBlock",
+                  "targets"
+                ],
                 "properties": {
-                  "blockType": { "type": "string" },
-                  "cellBlock": { "type": "string" },
+                  "blockType": {
+                    "type": "string"
+                  },
+                  "cellBlock": {
+                    "type": "string"
+                  },
                   "targets": {
                     "type": "array",
                     "items": {
                       "title": "Target",
                       "description": "The representational data of a target.",
                       "type": "object",
-                      "required": ["name", "actions"],
+                      "required": [
+                        "name",
+                        "actions"
+                      ],
                       "properties": {
-                        "name": { "type": "string" },
+                        "name": {
+                          "type": "string"
+                        },
                         "actions": {
                           "type": "array",
                           "items": {
@@ -115,8 +123,12 @@
                             "description": "The representational data of an action (w/o derivation).",
                             "type": "object",
                             "properties": {
-                              "name": { "type": "string" },
-                              "description": { "type": "string" }
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
                             }
                           }
                         }
@@ -131,52 +143,72 @@
       }
     },
     "ci": {
-      "title": "CI w/o Drvs",
-      "description": "A cheap evaluation that provides all necessary metadata without evaluating any derivations.",
+      "title": "CI",
+      "description": "An evaluation that provides all necessary metadata and evaluated derivations.",
       "type": "object",
       "additionalProperties": {
         "title": "System",
-        "type": "array",
-        "items": { "$ref": "#/$defs/ci-task" }
-      }
-    },
-    "ci-prime": {
-      "title": "CI w/ Drvs",
-      "description": "An expensive evaluation that provides all necessary metadata including evaluated derivations.",
-      "type": "object",
-      "additionalProperties": {
-        "title": "System",
+        "description": "Actions are namespaced per system as a derviation is only valid for its specified system.",
         "type": "array",
         "items": {
-          "title": "CI Task w/ Drvs",
-          "description": "A representation of a CI task that includes evaluated derviations.",
-          "allOf": [
-            { "$ref": "#/$defs/ci-task" },
-            {
-              "type": "object",
-              "title": "Drvs extension",
-              "description": "The expensive-to-evaluate derivations.",
-              "properties": {
-                "actionDrv": {
-                  "type": "string",
-                  "description": "The evaluated derivation for the action runnable."
-                },
-                "targetDrv": {
-                  "type": "string",
-                  "description": "The evaluated derivation for the target (if target is a derivation)."
-                },
-                "proviso": {
-                  "type": "string",
-                  "description": "A provisio which lets a CI cheaply decide whether running an action can be skipped."
-                },
-                "meta": {
-                  "type": "string",
-                  "description": "Arbitrary metadata needed during the priviso or discovery."
-                }
-              },
-              "required": ["actionDrv"]
+          "title": "CI Discovery Candidate",
+          "description": "A CI discovery candidate.",
+          "type": "object",
+          "required": [
+            "action",
+            "block",
+            "blockType",
+            "cell",
+            "name",
+            "actionDrv"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "description": "The name of the action."
+            },
+            "block": {
+              "type": "string",
+              "description": "The block name."
+            },
+            "blockType": {
+              "type": "string",
+              "description": "The block type."
+            },
+            "cell": {
+              "type": "string",
+              "description": "The cell name."
+            },
+            "name": {
+              "type": "string",
+              "description": "The target name."
+            },
+            "actionDrv": {
+              "type": "string",
+              "description": "The evaluated derivation for the action runnable."
+            },
+            "targetDrv": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The evaluated derivation for the target (if target is a derivation)."
+            },
+            "proviso": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A provisio which lets a CI cheaply decide whether running an action can be skipped."
+            },
+            "meta": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Arbitrary metadata needed during the priviso or discovery."
             }
-          ]
+          }
         }
       }
     }

--- a/tests/_snapshots/grow
+++ b/tests/_snapshots/grow
@@ -99,12 +99,6 @@
       x86_64-darwin = [ ];
       x86_64-linux = [ ];
     };
-    ci' = {
-      aarch64-darwin = [ ];
-      aarch64-linux = [ ];
-      x86_64-darwin = [ ];
-      x86_64-linux = [ ];
-    };
     init = {
       aarch64-darwin = [
         {


### PR DESCRIPTION
- refactor(grow)!: merge ci' into ci as the distinction remained unused so far
- refactor(grow)!: make ci action's proviso and meta nullable values
- docs: reflect schema changes in json schema

This refactoring is an api-incompatible change and requires a corresponding
update of `std-action`.

**Rationale**

This refactoring is done in preparation of a project rebase on haumea with
the goal of anticipating the api incompatible changes and detach them from
the actual rebase.
