### PR TITLE
Implement cell block introspection

### DIFF
--- a/grow/default.nix
+++ b/grow/default.nix
@@ -110,10 +110,7 @@
             outputMeta =
               res.output
               // {
-                __std = {
-                  inherit cellName;
-                  cellBlockName = cellBlock.name;
-                };
+                __cr = [cellName cellBlock.name];
               };
           in
             _ImportSignatureFor outputMeta cellP.flake; # recursion on cell

--- a/grow/default.nix
+++ b/grow/default.nix
@@ -105,7 +105,18 @@
           blockP = paths.cellBlockPath cellP cellBlock;
           isFile = l.pathExists blockP.file;
           isDir = l.pathExists blockP.dir;
-          signature = _ImportSignatureFor res.output cellP.flake; # recursion on cell
+          signature = let
+            # pass through the current cell and cell block names for introspection
+            outputMeta =
+              res.output
+              // {
+                __std = {
+                  inherit cellName;
+                  cellBlockName = cellBlock.name;
+                };
+              };
+          in
+            _ImportSignatureFor outputMeta cellP.flake; # recursion on cell
           import' = {
             displayPath,
             importPath,


### PR DESCRIPTION
Pass the cell name and cell block name into a `__cr` attribute on the `cell` input. This allows retrieving the name of the cell and the name of the cell block from within cell code.

The use case for this, for me, is for automatically generating `key` attributes for NixOS modules, to allow for automatic import deduplication. This allows creating a unique path that includes the Nix store path, cell name, cell block name, and the path of the import from Haumea.