### PR TITLE
feat: add support for require args

### DIFF
--- a/grow/newExtractFor.nix
+++ b/grow/newExtractFor.nix
@@ -64,6 +64,10 @@ in {
         l.mapAttrsToList (name: a: {
           inherit name;
           inherit (a) description;
+          requiresArgs =
+            if (target ? meta && target.meta ? requiresArgs)
+            then (builtins.elem name target.meta.requiresArgs)
+            else false;
         })
         actions';
     }


### PR DESCRIPTION
# Context

Sometimes an action command _really_ won't run without an argument.

At the same time argument are opaque to us, unfortunactely. (there's no protocol to advertise cli structure to an invoking process)

But still, we can state that an argument _is_ required and then fail early.

# TUI changes

- This requires a tui version which contains this feature to work

# Config

On a given target, make sure to add the following special meta flag:

```nix
{
  meta = {
    requiresArgs = ["run"]; # mention the name of your action for this target
  };
}
```
